### PR TITLE
Add tracking of incito section opens

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,6 +10,7 @@ This release adds support for the async/await model of concurrency. It changes b
 - `APIRequest` now no longer has a version tag. If you need to define a new APIRequest, you define the endpoint version by picking the correct `.v2()` or `.v4()` static initializers function.
 - `TjekAPI.initialize` will now fatalError if called more than once. In order to re-initialize the API, you must call `await TjekAPI.shared.update(config:)`
 
+It also adds a section-opened event to the incito publication viewer.
 
 ## v5.0.3
 

--- a/Package.swift
+++ b/Package.swift
@@ -16,7 +16,7 @@ let package = Package(
         .library(name: "TjekPublicationViewer", targets: ["TjekPublicationViewer"])
     ],
     dependencies: [
-        .package(name: "Incito", url: "https://github.com/tjek/incito-ios.git", from: "1.0.3"),
+        .package(name: "Incito", url: "https://github.com/tjek/incito-ios.git", from: "1.0.6"),
         .package(name: "Future", url: "https://github.com/tjek/swift-future.git", from: "0.5.0"),
         .package(name: "Verso", url: "https://github.com/tjek/verso-ios.git", from: "1.0.6"),
         .package(name: "Kingfisher", url: "https://github.com/onevcat/Kingfisher.git", from: "7.0.0"),

--- a/Sources/TjekEventsTracker/Event+SDKEvents.swift
+++ b/Sources/TjekEventsTracker/Event+SDKEvents.swift
@@ -25,6 +25,7 @@ extension Event {
         case searchResultsViewed            = 9
         case incitoPublicationOpened_v2     = 11
         case basicAnalytics                 = 12
+        case incitoPublicationSectionOpened = 13
     }
     
     /**
@@ -347,6 +348,39 @@ extension Event {
                      type: EventType.searchResultsViewed.rawValue,
                      payload: payload)
     }
+    
+    /**
+     The event when an incito section has disappeared from screen. Uniqueness is defined by the publicationId and the sectionPosition.
+     - parameter publicationId: The uuid of the incito.
+     - parameter sectionId: The id of the section that was opened (provided by the webview).
+     - parameter sectionPosition: The position of the section that was opened (provided by the webview)
+     - parameter openedAt: The date that the section appeared on screen.
+     - parameter millisecsOnScreen: The number of milliseconds the section was on screen.
+     - parameter tokenizer: A Tokenizer for generating the unique view token. Defaults to the shared EventsTrackers's viewTokenizer.
+     */
+    internal static func _incitoPublicationSectionOpened(
+        _ publicationId: PublicationId,
+        sectionId: String,
+        sectionPosition: Int,
+        openedAt: Date,
+        millisecsOnScreen: Int,
+        tokenizer: Tokenizer = TjekEventsTracker.shared.viewTokenizer.tokenize
+    ) -> Event {
+        
+        let payload: PayloadType = [
+            "ip.id": .string(publicationId.rawValue),
+            "ips.id": .string(sectionId),
+            "ips.p": .int(sectionPosition),
+            "mos": .int(millisecsOnScreen)
+        ]
+        
+        let viewTokenContent = "\(sectionId).\(sectionPosition)"
+        
+        return Event(timestamp: openedAt,
+                     type: EventType.incitoPublicationSectionOpened.rawValue,
+                     payload: payload)
+            .addingViewToken(content: viewTokenContent, tokenizer: tokenizer)
+    }
 }
 
 extension Event {
@@ -446,5 +480,15 @@ extension Event {
         resultsViewedCount: Int
     ) -> Event {
         return _searchResultsViewed(query: query, languageCode: languageCode, resultsViewedCount: resultsViewedCount, timestamp: Date())
+    }
+    
+    public static func incitoPublicationSectionOpened(
+        _ publicationId: PublicationId,
+        sectionId: String,
+        sectionPosition: Int,
+        openedAt: Date,
+        millisecsOnScreen: Int
+    ) -> Event {
+        return _incitoPublicationSectionOpened(publicationId, sectionId: sectionId, sectionPosition: sectionPosition, openedAt: openedAt, millisecsOnScreen: millisecsOnScreen)
     }
 }

--- a/Sources/TjekPublicationViewer/IncitoPublication/IncitoLoaderViewController+v4APILoader.swift
+++ b/Sources/TjekPublicationViewer/IncitoPublication/IncitoLoaderViewController+v4APILoader.swift
@@ -156,6 +156,21 @@ extension IncitoLoaderViewController {
             case let .success(viewController):
                 let firstLoad = !hasLoadedIncito
                 hasLoadedIncito = true
+                let prevHandler = viewController.sectionViewedEventHandler
+                viewController.sectionViewedEventHandler = { event in
+                    prevHandler(event)
+                    
+                    // ignore short events
+                    guard event.duration > 0.3 else {
+                        return
+                    }
+                    
+                    if TjekEventsTracker.isInitialized {
+                        TjekEventsTracker.shared.trackEvent(
+                            .incitoPublicationSectionOpened(publicationId, sectionId: event.id.sectionId, sectionPosition: event.id.sectionPosition, openedAt: event.appeared, millisecsOnScreen: Int(event.duration * 1000))
+                        )
+                    }
+                }
                 completion?(.success((viewController, firstLoad)))
             case let .failure(error):
                 completion?(.failure(error))

--- a/TjekSDK.podspec
+++ b/TjekSDK.podspec
@@ -36,7 +36,7 @@ Pod::Spec.new do |s|
         
         ss.frameworks   = "Foundation", "UIKit"
         
-        ss.dependency "Incito", "~> 1.0"
+        ss.dependency "Incito", "~> 1.0.6"
         ss.dependency "Tjek-Future", "~> 0.5"
         ss.dependency "Verso", "~> 1.0"
         ss.dependency "Kingfisher", "~> 7.0"

--- a/TjekSDK.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/TjekSDK.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -6,8 +6,8 @@
         "repositoryURL": "https://github.com/tjek/incito-ios.git",
         "state": {
           "branch": null,
-          "revision": "97009ac8fc4883bc6defda0c2741b4a7c9b30092",
-          "version": "1.0.5"
+          "revision": "833518f698659486194d839fcf56e4998c644a8f",
+          "version": "1.0.6"
         }
       },
       {


### PR DESCRIPTION
In order for this to be suitable for widespread SDK use, we must update the Incito SPM dep to point to the updated version. otherwise 🧨 